### PR TITLE
flesh out to_subgraph

### DIFF
--- a/docs/swd/SDD001.md
+++ b/docs/swd/SDD001.md
@@ -13,7 +13,7 @@ level: 1.0
 links: []
 normative: false
 ref: ''
-reviewed: CBBiow1cH46mbWjs1CtYziPGBe093_C6OLEOyz4nx6s=
+reviewed: H3EShUro_11wKR5s-QNvm8wWsXQGJwGBQWu7fGTBF1U=
 ---
 
 # Design Elements
@@ -40,7 +40,7 @@ Doorstop-To-Mermaid Software Units (captured from mermaid to SVG or PNG).
   <summary>ds2m_dependency_graph source</summary>
   ds2mermaid dependency graph showing primary software units.
 
-```mermaid
+```
   graph TB
     subgraph id1[ds2mermaid Dependencies]
       subgraph id2[Python Packages]

--- a/tests/test_diagram.py
+++ b/tests/test_diagram.py
@@ -9,15 +9,31 @@ def test_graph_subgraph():
     Test we can create and manipulate subgraph objects.
     Verifies REQ005 and REQ006 for subgraph.nodes
     """
-    node_lst = ["REQ001", "REQ002", "REQ003", "REQ004", "REQ005", "REQ006", "REQ007"]
-    expected = ["REQ001", "REQ002", "REQ003", "REQ004", "REQ005", "REQ006", "REQ007"]
-    subgraph = SubGraph("REQ", node_lst)
-    assert subgraph.name == "REQ"
+    node_lst = [
+        "REQS001",
+        "REQS002",
+        "REQS003",
+        "REQS004",
+        "REQS005",
+        "REQS006",
+        "REQS007",
+    ]
+    expected = [
+        "REQS001",
+        "REQS002",
+        "REQS003",
+        "REQS004",
+        "REQS005",
+        "REQS006",
+        "REQS007",
+    ]
+    subgraph = SubGraph("REQS", node_lst)
+    assert subgraph.name == "REQS"
     assert len(subgraph.nodes) == 7
     assert isinstance(subgraph.nodes, list)
-    subgraph.add_node("REQ008")
+    subgraph.add_node("REQS008")
     assert len(subgraph.nodes) == 8
-    expected.append("REQ008")
+    expected.append("REQS008")
     assert subgraph.nodes == expected
     print(subgraph.nodes)
 


### PR DESCRIPTION
* rename test bits to avoid name clashes in doorstop docs
* flesh out `to_subgraph`, add script driver